### PR TITLE
making it so that it registers a new config.app_generator for javascript_

### DIFF
--- a/lib/haml_assets/engine.rb
+++ b/lib/haml_assets/engine.rb
@@ -7,3 +7,11 @@ module HamlAssets
     end
   end
 end
+
+module HamlAssets
+  class Railtie < ::Rails::Railtie
+    if ::Rails.version.to_f >= 3.1
+      config.app_generators.javascript_template_engine :haml
+    end
+  end
+end


### PR DESCRIPTION
I've been working on my personal fork of [Backbone Rails](https://github.com/christopherhein/backbone-rails/tree/develop) and have added the ability to use haml as a jst template format, though the generators, but currently there is no way to detect if the user is trying to use html or haml in the asset pipeline or not. So I added a railtie that adds `config.app_generators.javascript_templating_engine :haml`, like the way that the [haml rails](https://github.com/indirect/haml-rails) registers `config.app_generators.template_engine :haml` this way in the backbone-rails gem when someone has installed this gem, it will default all the templates to using haml.

if you'd like to test it because I have yet to put in the pull request to @codebrews [backbone-rails repo](https://github.com/codebrew/backbone-rails) you will need to use my [`develop`](https://github.com/christopherhein/backbone-rails/tree/develop) fork and any generator with this fork of haml_assets that would create templates. ie scaffold or router

Let me know if you have any questions or concerns.

Thanks!
