### PR TITLE
Use `render :partial` to move duplicated code into separate templates

### DIFF
--- a/lib/haml_assets/haml_sprockets_engine.rb
+++ b/lib/haml_assets/haml_sprockets_engine.rb
@@ -8,7 +8,15 @@ module HamlAssets
     end
 
     module ViewContext
-      attr_accessor :output_buffer
+      attr_accessor :output_buffer, :_view_renderer, :_lookup_context
+
+      def view_renderer
+        @_view_renderer ||= ActionView::Renderer.new(lookup_context)
+      end
+
+      def lookup_context
+        @_lookup_context ||= ActionView::LookupContext.new(Rails.root.join("app", "assets", "templates"))
+      end
 
       def output_buffer_with_haml
         return haml_buffer.buffer if is_haml?


### PR DESCRIPTION
Hey,

I'd like to use `render :partial` like I'm using it on the server side, to move duplicated code into separate templates - but this does not work atm.

It's easy to enable and works well for me. Since I'm not sure if this is the best approach to enable this functionality I've opened this pull request, for discussion mostly. Maybe `haml_assets` is not the best place to enable this functionality in...

Anyway, thanks for the great gem!
