### PR TITLE
Limit files included in the build

### DIFF
--- a/haml_assets.gemspec
+++ b/haml_assets.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "haml_assets"
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = Dir['Rakefile', '{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]

--- a/lib/haml_assets/version.rb
+++ b/lib/haml_assets/version.rb
@@ -1,3 +1,3 @@
 module HamlAssets
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
We only need a few dirs and files to be included in the final gem, not
dotfiles, Dockerfiles, etc.